### PR TITLE
Correct `crash_log_msg_side` to `crash_log_msg_size`

### DIFF
--- a/manifests/appconfig.pp
+++ b/manifests/appconfig.pp
@@ -92,7 +92,7 @@ class riak::appconfig(
           ['__tuple', $riak::params::info_log,  '__atom_info', 10485760, '$D0', 5],
         ]},
       crash_log             => $riak::params::crash_log,
-      crash_log_msg_side    => 65536,
+      crash_log_msg_size    => 65536,
       crash_log_size        => 10485760,
       crash_log_date        => '$D0',
       crash_log_count       => 5,


### PR DESCRIPTION
Minor typo.

http://docs.basho.com/riak/1.4.12/ops/advanced/configs/configuration-files/